### PR TITLE
fix: add cross-platform compatibility for npm test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,13 @@ npm test
 npm run build:watch
 ```
 
+## Windows Users
+
+If you encounter issues with `npm test`, this project uses cross-env for cross-platform compatibility. The setup should work automatically, but if you encounter issues:
+
+1. Ensure you're using Git Bash or WSL
+2. Or use PowerShell/Command Prompt after running `npm install`
+
 ### Project Structure
 
 - `src/` - TypeScript source files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "decision-tree",
-  "version": "0.3.7",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "decision-tree",
-      "version": "0.3.7",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
@@ -15,6 +15,7 @@
         "@types/lodash": "^4.17.20",
         "@types/mocha": "^10.0.10",
         "@types/node": "^24.3.0",
+        "cross-env": "^10.0.0",
         "esm": "^3.2.25",
         "mocha": "^11.7.1",
         "ts-node": "^10.9.2",
@@ -36,6 +37,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -394,6 +402,24 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1416,6 +1442,12 @@
         "@jridgewell/trace-mapping": "0.3.9"
       }
     },
+    "@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true
+    },
     "@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1679,6 +1711,16 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "requires": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      }
     },
     "cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/lodash": "^4.17.20",
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.3.0",
+    "cross-env": "^10.0.0",
     "esm": "^3.2.25",
     "mocha": "^11.7.1",
     "ts-node": "^10.9.2",
@@ -38,7 +39,7 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",
-    "test": "npm run build && NODE_PATH=. ./node_modules/.bin/mocha --require ts-node/register -R spec tst/*.ts",
+    "test": "npm run build && cross-env NODE_PATH=. mocha --require ts-node/register -R spec tst/*.ts",
     "test:watch": "npm run build && NODE_PATH=. ./node_modules/.bin/mocha --require ts-node/register -R spec --watch tst/*.ts",
     "clean": "rm -rf lib",
     "prepublishOnly": "npm run clean && npm run build",


### PR DESCRIPTION
## Description
Fixed cross-platform compatibility issue with npm test script on Windows.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] All existing tests pass
- [x] Tested on Windows with Git Bash
- [x] No breaking changes

## Problem Solved
Windows users were unable to run `npm test` due to NODE_PATH environment variable syntax. This fix uses cross-env to make the script work across all platforms.